### PR TITLE
feat(LOC-2183): Prepare add-on for bundling directly with Local

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
-  "name": "local-addon-image-optimizer",
+  "name": "@getflywheel/local-addon-image-optimizer",
   "productName": "image-optimizer",
-  "version": "1.0.0",
+  "local": { "hidden": true },
+  "version": "0.0.2",
   "author": "Local Team",
   "keywords": [
     "local-addon"
@@ -14,10 +15,10 @@
   "main": "lib/main.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/getflywheel/local-addon-boilerplate"
+    "url": "https://github.com/getflywheel/local-addon-image-optimizer"
   },
   "bugs": {
-    "url": "https://github.com/getflywheel/local-addon-boilerplate/issues"
+    "url": "https://github.com/getflywheel/local-addon-image-optimizer/issues"
   },
   "license": "MIT",
   "scripts": {

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -38,22 +38,16 @@ export default async function (context) {
 	hooks.addContent('routesSiteInfo', () => (
 		<Route
 			key={`${addonID}-addon`}
-			path={`/main/site-info/:siteID/${addonID}`}
+			path={`/main/site-info/:siteID/imageOptimizer`}
 			render={withStoreProvider(ImageOptimizer)}
 		/>
 	));
 
-	// Add menu option within the site menu bar
-	hooks.addFilter('siteInfoMoreMenu', function (menu, site) {
-		menu.push({
-			label: `${addonName}`,
-			enabled: true,
-			click: () => {
-				context.events.send('goToRoute', `/main/site-info/${site.id}/${addonID}`);
-			}
-		});
-
-		return menu;
+	hooks.addContent('imageOptimizer', function (props) {
+		const EnhancedImageOptimizer = withStoreProvider(ImageOptimizer);
+		return (
+			<EnhancedImageOptimizer {...props} />
+		);
 	});
 
 	hooks.addFilter(


### PR DESCRIPTION
## Summary

- Swaps out a filter hook for a content hook (so that Local can render the content directly where it needs to)
- Prepares `package.json` for `npm publish`. It's worth noting that this has been deployed as a private package to NPM. It is currently on version `0.0.2`. When we are confident in the initial release, we can bump and deploy version `1.0.0`.

## Reference
- [LOC-2183](https://getflywheel.atlassian.net/browse/LOC-2183)
- [Sister Local PR](https://github.com/getflywheel/flywheel-local/pull/854)