### PR TITLE
chore: bump version to 0.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "local": {
     "hidden": true
   },
-  "version": "0.0.3",
+  "version": "0.0.4",
   "author": "Local Team",
   "keywords": [
     "local-addon"


### PR DESCRIPTION
Bumping version to 0.0.4 to see if I can resolve an issue with v0.0.3