### PR TITLE
feat: do not compile unecessary things with tsc

### DIFF
--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -3,7 +3,7 @@ import path from 'path';
 import { Provider } from 'react-redux';
 import * as LocalRenderer from '@getflywheel/local/renderer';
 import { IPC_EVENTS } from './constants';
-import makeStore from './store';
+import makeStore from './renderer/store';
 import ImageOptimizer from './renderer/index';
 import { MetaDataRow } from './renderer/preferencesRows';
 

--- a/src/renderer/reducers.ts
+++ b/src/renderer/reducers.ts
@@ -1,7 +1,7 @@
 /**
  * This serves as the centralized point for all Redux store reducers
  */
-import { PREFERENCES_REDUCER_ACTION_TYPES } from './constants';
+import { PREFERENCES_REDUCER_ACTION_TYPES } from '../constants';
 
 export const preferencesReducer = (state = {}, action) => {
 	switch(action.type) {

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -1,7 +1,7 @@
 import { createStore, combineReducers } from 'redux';
 import * as LocalRenderer from '@getflywheel/local/renderer';
-import { IPC_EVENTS } from './constants';
-import { Preferences } from './types';
+import { IPC_EVENTS } from '../constants';
+import { Preferences } from '../types';
 import { preferencesReducer } from './reducers'
 
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,10 @@
 		"target": "es2015"
 	},
 	"exclude": [
-		"node_modules"
+		"src/**/*.test.ts",
+		"src/test",
+		"src/renderer",
+		"src/renderer.tsx"
 	],
 	"include": [
 		"src"


### PR DESCRIPTION
### Summary

We are compiling and including in `lib` some unecessary things including
- render thread stuff (which is now compiled and handled with webpack)
- test files (we do not need these in the compiled source)

This results in the compiled code (contents of `lib`) reduced by ~69(nice)%. Sizes were checked with `du -sh lib`

Before `lib` was `672kb`
<img width="1304" alt="Screen Shot 2020-10-09 at 4 34 03 PM" src="https://user-images.githubusercontent.com/21110659/95633744-f7bc3b80-0a4d-11eb-8814-d49a36410c17.png">

Afterwards, it is `468kb`
<img width="1302" alt="Screen Shot 2020-10-09 at 4 34 32 PM" src="https://user-images.githubusercontent.com/21110659/95633750-fa1e9580-0a4d-11eb-8b67-b3ecee8880b6.png">


