### PR TITLE
feat(LOC-2242): de-dupe backup filenames

### DIFF
--- a/src/main/compressImages.ts
+++ b/src/main/compressImages.ts
@@ -66,7 +66,17 @@ export function compressImagesFactory(serviceContainer: LocalMain.ServiceContain
 			 * We still include "uploads" in this new file path even though that is the "base" from which we scan
 			 * for images so that we can easily expand this to scan other directories within wp-content in the future
 			 */
-			const backupPath = filePath.replace(path.join(site.paths.webRoot, 'wp-content'), backupDirPath);
+			let backupPath = filePath.replace(path.join(site.paths.webRoot, 'wp-content'), backupDirPath);
+			const { dir, name, ext } = path.parse(backupPath);
+
+			let deDupeCounter = 1;
+
+			while (fs.existsSync(backupPath)) {
+				const tempName = `${name} (${deDupeCounter})${ext}`;
+				backupPath = path.join(dir, tempName);
+
+				deDupeCounter++;
+			}
 
 			fs.copySync(filePath, backupPath);
 
@@ -138,3 +148,4 @@ export function compressImagesFactory(serviceContainer: LocalMain.ServiceContain
 		serviceContainer.sendIPCEvent(IPC_EVENTS.COMPRESS_ALL_IMAGES_COMPLETE);
 	}
 };
+


### PR DESCRIPTION
### Summary
We currently do not check before overwriting backed up image files. This adds deduping so that we never overwrite a backup file.

### Technical

If a file exists, then an incrememnter in the form of ` (x)` is added between the file name and the extension.

_example_
```
'cool-image.jpg' -> 'cool-image (1).jpg' -> 'cool-image (2).jpg'
```

An example of some de-duped backup images looks like this:
<img width="771" alt="Screen Shot 2020-10-13 at 12 45 33 PM" src="https://user-images.githubusercontent.com/21110659/95897938-eb88f480-0d53-11eb-8b8d-161727e33749.png">


### Reference
- [LOC-2242](https://getflywheel.atlassian.net/browse/LOC-2242)