### PR TITLE
feat(LOC-2184): Add reporting to image optimizer

### DIFF
--- a/src/main/errorReporting.ts
+++ b/src/main/errorReporting.ts
@@ -1,0 +1,37 @@
+import * as LocalMain from '@getflywheel/local/main';
+import fs from 'fs-extra';
+import path from 'path';
+const packageJSON = fs.readJsonSync(path.join(__dirname, '../../package.json'));
+
+const { localLogger } = LocalMain.getServiceContainer().cradle;
+
+const logger = localLogger.child({
+    thread: 'main',
+    class: 'AddonImageOptimizer',
+    addonName: packageJSON.name,
+    addonVersion: packageJSON.version,
+});
+
+export const reportScanRequest = (siteID: string) => {
+    logger.info(`Scanning REQUEST for site ${siteID}`);
+}
+
+export const reportScanSuccess = (siteID: string, imageCount: number, totalCompressedCount: number) => {
+    logger.info(`Scanning SUCCESS for site ${siteID}. Found ${imageCount} image(s). ${totalCompressedCount} already compressed.`);
+}
+
+export const reportScanFailure = (siteID: string, error: typeof Error) => {
+    logger.error(`Scanning FAILURE for site ${siteID}. ${error}.`);
+}
+
+export const reportCompressRequest = (siteID: string) => {
+    logger.info(`Compress REQUEST for site ${siteID}`);
+}
+
+export const reportCompressSuccess = (siteID: string, imageCount: number) => {
+    logger.info(`Compress SUCCESS for site ${siteID}. Compressed ${imageCount} image(s).`);
+}
+
+export const reportCompressFailure = (siteID: string, error: typeof Error) => {
+    logger.error(`Compress FAILURE for site ${siteID}. ${error}.`);
+}

--- a/src/main/scanImages.ts
+++ b/src/main/scanImages.ts
@@ -3,7 +3,7 @@ import * as LocalMain from '@getflywheel/local/main';
 import { SiteImageData, Store } from '../types';
 import { saveImageDataToDisk } from './utils';
 import { IPC_EVENTS } from '../constants';
-
+import { reportScanRequest, reportScanSuccess, reportScanFailure } from './errorReporting';
 
 /**
  * Scans a site's wp-content dir for images
@@ -14,118 +14,125 @@ import { IPC_EVENTS } from '../constants';
  * @returns ImageData[]
  */
 export function scanImagesFactory(serviceContainer: LocalMain.ServiceContainerServices, imageDataStore: Store) {
-	return async function(siteID: string) {
-		const site = serviceContainer.siteData.getSite(siteID);
-		let siteData = imageDataStore.getStateBySiteID(siteID);
-		const imageData = siteData.imageData || {};
+	return async function (siteID: string) {
+		try {
+			reportScanRequest(siteID);
+			const site = serviceContainer.siteData.getSite(siteID);
+			let siteData = imageDataStore.getStateBySiteID(siteID);
+			const imageData = siteData.imageData || {};
 
-		if (!site) {
-			serviceContainer.sendIPCEvent(IPC_EVENTS.SCAN_IMAGES_FAILURE, new Error('Site not found!'));
-			return;
-		}
+			if (!site) {
+				serviceContainer.sendIPCEvent(IPC_EVENTS.SCAN_IMAGES_FAILURE, new Error('Site not found!'));
+				return;
+			}
 
-		const scanningSiteImageData: Partial<SiteImageData> = {
-			scanInProgress: true,
-		};
+			const scanningSiteImageData: Partial<SiteImageData> = {
+				scanInProgress: true,
+			};
 
-		imageDataStore.setStateBySiteID(siteID, scanningSiteImageData);
+			imageDataStore.setStateBySiteID(siteID, scanningSiteImageData);
 
-		saveImageDataToDisk(imageDataStore, serviceContainer);
+			saveImageDataToDisk(imageDataStore, serviceContainer);
 
-		siteData = imageDataStore.getStateBySiteID(siteID);
+			siteData = imageDataStore.getStateBySiteID(siteID);
 
-		/**
-		 * @todo - remove @ts-ignore once the new Local api changes are published
-		 */
-		// @ts-ignore
-		const childProcess = LocalMain.workerFork(
-			path.join(__dirname, 'scanImagesProcess'),
-		);
-
-		/**
-		 * @todo - remove @ts-ignore once the new Local api changes are published
-		 */
-		// @ts-ignore
-		const processMessageHelper: (name: string, payload?: any) => any = LocalMain.childProcessMessagePromiseFactory(childProcess);
-
-		/**
-		 * @todo - remove @ts-ignore once the new Local api changes are published
-		 */
-		// @ts-ignore
-		const filePaths = await processMessageHelper<string[]>(
-			'get-file-paths',
-			{
-				webRoot: site.paths.webRoot,
-			},
-		);
-
-		/**
-		 * @todo - remove @ts-ignore once the new Local api changes are published
-		 */
-		// @ts-ignore
-		const updatedImageData = await processMessageHelper<SiteImageData['imageData']>(
-			'get-image-stats',
-			{
-				filePaths,
-				imageData,
-			},
 			/**
-			 * @todo - kill the type casting once this is exposed in Local API
+			 * @todo - remove @ts-ignore once the new Local api changes are published
 			 */
-		) as SiteImageData['imageData'];
+			// @ts-ignore
+			const childProcess = LocalMain.workerFork(
+				path.join(__dirname, 'scanImagesProcess'),
+			);
 
-		const totalImagesSize = await Object.values(updatedImageData).reduce(
-			(acc, data) => {
-				return acc + data.originalSize;
-			}, 0
-		);
+			/**
+			 * @todo - remove @ts-ignore once the new Local api changes are published
+			 */
+			// @ts-ignore
+			const processMessageHelper: (name: string, payload?: any) => any = LocalMain.childProcessMessagePromiseFactory(childProcess);
 
-		const compressedTotalSize = await Object.values(updatedImageData).reduce(
-			(acc, data) => {
-				if (typeof data.compressedSize === 'number') {
-					return acc + data.compressedSize;
-				} else {
-					return acc;
-				}
-			}, 0
-		);
+			/**
+			 * @todo - remove @ts-ignore once the new Local api changes are published
+			 */
+			// @ts-ignore
+			const filePaths = await processMessageHelper<string[]>(
+				'get-file-paths',
+				{
+					webRoot: site.paths.webRoot,
+				},
+			);
 
-		const totalCompressedCount = await Object.values(updatedImageData).reduce(
-			(acc, data) => {
-				if (data.compressedImageHash) {
-					return acc + 1;
-				} else {
-					return acc;
-				}
-			}, 0
-		);
+			/**
+			 * @todo - remove @ts-ignore once the new Local api changes are published
+			 */
+			// @ts-ignore
+			const updatedImageData = await processMessageHelper<SiteImageData['imageData']>(
+				'get-image-stats',
+				{
+					filePaths,
+					imageData,
+				},
+				/**
+				 * @todo - kill the type casting once this is exposed in Local API
+				 */
+			) as SiteImageData['imageData'];
 
-		const compressedImagesOriginalSize = await Object.values(updatedImageData).reduce(
-			(acc, data) => {
-				if (data.compressedImageHash) {
+			const totalImagesSize = await Object.values(updatedImageData).reduce(
+				(acc, data) => {
 					return acc + data.originalSize;
-				} else {
-					return acc;
-				}
-			}, 0
-		);
+				}, 0
+			);
 
-		const nextSiteImageData = {
-			...siteData,
-			imageData: updatedImageData,
-			scanInProgress: false,
-			lastScan: Date.now(),
-			originalTotalSize: totalImagesSize,
-			compressedTotalSize: compressedTotalSize,
-			imageCount: filePaths.length,
-			totalCompressedCount: totalCompressedCount,
-			compressedImagesOriginalSize: compressedImagesOriginalSize,
-		};
+			const compressedTotalSize = await Object.values(updatedImageData).reduce(
+				(acc, data) => {
+					if (typeof data.compressedSize === 'number') {
+						return acc + data.compressedSize;
+					} else {
+						return acc;
+					}
+				}, 0
+			);
 
-		imageDataStore.setStateBySiteID(siteID, nextSiteImageData);
+			const totalCompressedCount = await Object.values(updatedImageData).reduce(
+				(acc, data) => {
+					if (data.compressedImageHash) {
+						return acc + 1;
+					} else {
+						return acc;
+					}
+				}, 0
+			);
 
-		saveImageDataToDisk(imageDataStore, serviceContainer);
+			const compressedImagesOriginalSize = await Object.values(updatedImageData).reduce(
+				(acc, data) => {
+					if (data.compressedImageHash) {
+						return acc + data.originalSize;
+					} else {
+						return acc;
+					}
+				}, 0
+			);
 
-		serviceContainer.sendIPCEvent(IPC_EVENTS.SCAN_IMAGES_COMPLETE, nextSiteImageData);
+			const nextSiteImageData = {
+				...siteData,
+				imageData: updatedImageData,
+				scanInProgress: false,
+				lastScan: Date.now(),
+				originalTotalSize: totalImagesSize,
+				compressedTotalSize: compressedTotalSize,
+				imageCount: filePaths.length,
+				totalCompressedCount: totalCompressedCount,
+				compressedImagesOriginalSize: compressedImagesOriginalSize,
+			};
+
+			imageDataStore.setStateBySiteID(siteID, nextSiteImageData);
+
+			saveImageDataToDisk(imageDataStore, serviceContainer);
+
+			serviceContainer.sendIPCEvent(IPC_EVENTS.SCAN_IMAGES_COMPLETE, nextSiteImageData);
+			reportScanSuccess(siteID, filePaths.length, totalCompressedCount);
+		} catch (error) {
+			reportScanFailure(siteID, error);
+			return error;
+		}
 	}
 };


### PR DESCRIPTION
**Summary:** 

Adding information to the logs for support to know what's going on with Image Optimization.
- Show Image Scan Request/Success/Failure
- Show Image Compression Request/Success/Failure
- Add version of installed addon to logs

To test just run and view logs. If you want to test failures, then you can `throw new Error('some error here') within scan or compress functions.

![Screen Shot 2020-10-19 at 4 29 42 PM](https://user-images.githubusercontent.com/62450648/96516839-732ba300-122d-11eb-969f-5afd61cccb28.png)
![Screen Shot 2020-10-19 at 4 23 33 PM](https://user-images.githubusercontent.com/62450648/96516844-76269380-122d-11eb-975e-0da4e2e6b889.png)
![Screen Shot 2020-10-19 at 4 24 54 PM](https://user-images.githubusercontent.com/62450648/96516849-77f05700-122d-11eb-96c7-dc1ad6de1067.png)
