### PR TITLE
fix(LOC-2263): clean up existing image optimizer tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,7 @@
 module.exports = {
 	preset: 'ts-jest',
 	setupFilesAfterEnv: ['jest-extended'],
+	moduleNameMapper: {
+		'^@getflywheel/local/main': '<rootDir>/src/test/mockLocalMain.ts',
+	},
 };

--- a/src/main/compressImages.test.ts
+++ b/src/main/compressImages.test.ts
@@ -177,13 +177,16 @@ describe('compressImages', () => {
 
 	it('calls sendIPCEvent with the correct args when successful', () => {
 		const mock = mockServiceContainer.sendIPCEvent.mock;
+
 		let call = mock.calls[0];
 		expect(call[0]).toEqual(IPC_EVENTS.COMPRESS_IMAGE_STARTED);
-		expect(call[1]).toEqual(imageOneID);
+		expect(call[1]).toEqual(siteID);
+		expect(call[2]).toEqual(imageOneID);
 
 		call = mock.calls[1];
 		expect(call[0]).toEqual(IPC_EVENTS.COMPRESS_IMAGE_SUCCESS);
-		expect(call[1]).toContainKeys(expectedImageDataKeys);
+		expect(call[1]).toEqual(siteID);
+		expect(call[2]).toContainKeys(expectedImageDataKeys);
 	});
 
 	it('updates the store correctly when successful', () => {
@@ -191,27 +194,19 @@ describe('compressImages', () => {
 		let imageData = allImageData[imageOneID];
 
 		expect(imageData).toContainAllKeys(expectedImageDataKeys);
-
-		imageData = allImageData[imageTwoID];
-
-		expect(imageData).toContainAllKeys([
-			'originalImageHash',
-			'filePath',
-			'originalSize',
-		]);
 	});
 
 	it('calls sendIPCEvent with the correct args when unnsuccessful', () => {
 		const { mock } = mockServiceContainer.sendIPCEvent;
-
 		let call = mock.calls[3];
-		expect(call[0]).toEqual(IPC_EVENTS.COMPRESS_IMAGE_FAIL);
 
-		expect(call[1].originalImageHash).toEqual(imageTwoID);
-		expect(call[1].errorMessage).toBeString();
+		expect(call[0]).toEqual(IPC_EVENTS.COMPRESS_IMAGE_FAIL);
+		expect(call[1]).toEqual(siteID);
+		expect(call[2]).toEqual(imageTwoID);
+		expect(call[3]).toBeString();
 	});
 
-	it('does not update the store if the file did not successfully compress', () => {
+	it('updates the store with an error message if the file did not successfully compress', () => {
 		const { imageData: allImageData } = imageDataStore.getStateBySiteID(siteID);
 		let imageData = allImageData[imageTwoID];
 
@@ -219,6 +214,7 @@ describe('compressImages', () => {
 			'originalImageHash',
 			'filePath',
 			'originalSize',
+			'errorMessage'
 		]);
 	});
 
@@ -235,7 +231,8 @@ describe('compressImages', () => {
 		const call = mock.calls[5];
 
 		expect(call[0]).toEqual(IPC_EVENTS.COMPRESS_IMAGE_FAIL);
-		expect(call[1]).toEqual(imageThreeID);
-		expect(call[2]).toBeString();
+		expect(call[1]).toEqual(siteID);
+		expect(call[2]).toEqual(imageThreeID);
+		expect(call[3]).toBeString();
 	});
 });

--- a/src/main/errorReporting.ts
+++ b/src/main/errorReporting.ts
@@ -17,8 +17,8 @@ export const reportScanRequest = (siteID: string) => {
     logger.info(`Scanning REQUEST for site ${siteID}`);
 }
 
-export const reportScanSuccess = (siteID: string, imageCount: number, totalCompressedCount: number) => {
-    logger.info(`Scanning SUCCESS for site ${siteID}. Found ${imageCount} image(s). ${totalCompressedCount} already compressed.`);
+export const reportScanSuccess = (siteID: string, imageCount: number) => {
+    logger.info(`Scanning SUCCESS for site ${siteID}. Found ${imageCount} image(s).`);
 }
 
 export const reportScanFailure = (siteID: string, error: typeof Error) => {

--- a/src/main/scanImages.test.ts
+++ b/src/main/scanImages.test.ts
@@ -4,7 +4,6 @@ import { createMockServiceContainer } from '../test/mockCreators';
 import { scanImagesFactory } from './scanImages';
 import { createStore } from './createStore';
 
-
 const sitePath = '/Users/cool-man-joe/Local Sites/twice-baked-potato';
 const serviceContainer = createMockServiceContainer(sitePath);
 
@@ -26,7 +25,6 @@ describe('scanImages', () => {
 	);
 	const siteID = '1234';
 	let siteData;
-
 
 	beforeAll(async () => {
 
@@ -71,30 +69,8 @@ describe('scanImages', () => {
 
 	it('confirms siteData contains appropriate keys', () => {
 		expect(siteData).toContainAllKeys([
-			'scanInProgress',
 			'imageData',
-			'lastScan',
-			'originalTotalSize',
-			'compressedTotalSize',
-			'imageCount',
-			'totalCompressedCount',
-			'compressedImagesOriginalSize'
+			'lastScan'
 		]);
-	});
-
-	it('confirms originalTotalSize is calculated correctly', () => {
-		expect(siteData.originalTotalSize).toBe(17000000);
-	});
-
-	it('confirms compressedTotalSize is calculated correctly', () => {
-		expect(siteData.compressedTotalSize).toBe(8500000);
-	});
-
-	it('confirms totalCompressedCount is calculated correctly', () => {
-		expect(siteData.totalCompressedCount).toBe(2);
-	});
-
-	it('confirms compressedImagesOriginalSize is calculated correctly', () => {
-		expect(siteData.compressedImagesOriginalSize).toBe(17000000);
 	});
 });

--- a/src/main/scanImages.test.ts
+++ b/src/main/scanImages.test.ts
@@ -32,7 +32,7 @@ describe('scanImages', () => {
 
 		await scanImages(siteID);
 
-		siteImageData = imageDataStore.getStateBySiteID(siteID);
+		siteData = imageDataStore.getStateBySiteID(siteID);
 	});
 
 	it('calls serviceContainer.getSite', () => {
@@ -69,8 +69,8 @@ describe('scanImages', () => {
 		});
 	});
 
-	it('confirms siteImageData contains appropriate keys', () => {
-		expect(siteImageData).toContainAllKeys([
+	it('confirms siteData contains appropriate keys', () => {
+		expect(siteData).toContainAllKeys([
 			'scanInProgress',
 			'imageData',
 			'lastScan',
@@ -83,18 +83,18 @@ describe('scanImages', () => {
 	});
 
 	it('confirms originalTotalSize is calculated correctly', () => {
-		expect(siteImageData.originalTotalSize).toBe(17000000);
+		expect(siteData.originalTotalSize).toBe(17000000);
 	});
 
 	it('confirms compressedTotalSize is calculated correctly', () => {
-		expect(siteImageData.compressedTotalSize).toBe(8500000);
+		expect(siteData.compressedTotalSize).toBe(8500000);
 	});
 
 	it('confirms totalCompressedCount is calculated correctly', () => {
-		expect(siteImageData.totalCompressedCount).toBe(2);
+		expect(siteData.totalCompressedCount).toBe(2);
 	});
 
 	it('confirms compressedImagesOriginalSize is calculated correctly', () => {
-		expect(siteImageData.compressedImagesOriginalSize).toBe(17000000);
+		expect(siteData.compressedImagesOriginalSize).toBe(17000000);
 	});
 });

--- a/src/main/scanImages.test.ts
+++ b/src/main/scanImages.test.ts
@@ -3,17 +3,14 @@ import * as LocalMain from '@getflywheel/local/main';
 import { createMockServiceContainer } from '../test/mockCreators';
 import { scanImagesFactory } from './scanImages';
 import { createStore } from './createStore';
+import { workerFork } from '../test/mockLocalMain';
 
 const sitePath = '/Users/cool-man-joe/Local Sites/twice-baked-potato';
 const serviceContainer = createMockServiceContainer(sitePath);
 
 const imageDataStore = createStore();
 
-jest.mock('./errorReporting', () => ({
-	reportScanRequest: jest.fn(),
-	reportScanSuccess: jest.fn(),
-	reportScanFailure: jest.fn()
-}));
+jest.mock('./errorReporting');
 
 jest.mock('./utils');
 const utils = require('./utils');
@@ -35,6 +32,10 @@ describe('scanImages', () => {
 
 	it('calls serviceContainer.getSite', () => {
 		expect(serviceContainer.siteData.getSite.mock.calls).toBeArrayOfSize(1);
+	});
+
+	it('calls LocalMain.workerFork with the correct args', () => {
+		expect(workerFork.mock.calls).toBeArrayOfSize(1);
 	});
 
 	it('calls saveImageDataToDisk with the correct args', () => {

--- a/src/main/scanImages.ts
+++ b/src/main/scanImages.ts
@@ -73,16 +73,6 @@ export function scanImagesFactory(serviceContainer: LocalMain.ServiceContainerSe
 				 */
 			) as SiteData['imageData'];
 
-			const totalCompressedCount = Object.values(updatedImageData).reduce(
-				(acc, data) => {
-					if (data.compressedImageHash) {
-						return acc + 1;
-					} else {
-						return acc;
-					}
-				}, 0
-			);
-
 			const nextSiteData: SiteData = {
 				...siteData,
 				imageData: updatedImageData,
@@ -95,7 +85,7 @@ export function scanImagesFactory(serviceContainer: LocalMain.ServiceContainerSe
 
 			serviceContainer.sendIPCEvent(IPC_EVENTS.SCAN_IMAGES_COMPLETE, siteID, nextSiteData);
 
-			reportScanSuccess(siteID, filePaths.length, totalCompressedCount);
+			reportScanSuccess(siteID, filePaths.length);
 		} catch (error) {
 			reportScanFailure(siteID, error);
 			return error;

--- a/src/main/scanImagesProcess.test.ts
+++ b/src/main/scanImagesProcess.test.ts
@@ -1,0 +1,37 @@
+
+jest.mock('fs-extra');
+fs.statSync.mockImplementation((filePath: string) => ({
+	size: Math.floor(Math.random() * 99999) + 700
+}));
+
+
+const mockFilePaths = [
+	'fake/path/file1.jpeg',
+	'fake/path/file2.jpeg',
+];
+
+// mock out utils so that we don't accidentally make calls to fs, etc.
+// also this makes assertions much easier and utils should be tested independantly anyways
+jest.mock('./utils');
+const utils = require('./utils');
+utils.getImageFilePaths.mockImplementation(() => {
+	return mockFilePaths;
+});
+utils.getFileHash.mockImplementation((filePath) => {
+	return md5(filePath);
+});
+
+it('calls getImageFilePaths once with the correct args', () => {
+	expect(utils.getImageFilePaths.mock.calls).toBeArrayOfSize(1);
+
+	expect(utils.getImageFilePaths.mock.calls[0][0]).toEqual(
+		serviceContainer.siteData.getSite.mock.results[0].value.paths.webRoot
+	);
+});
+
+it('calls getFileHash once for each file ', () => {
+	const { mock } = utils.getFileHash;
+	expect(mock.calls).toBeArrayOfSize(mockFilePaths.length);
+	expect(mock.calls.map(call => call[0])).toIncludeSameMembers(mockFilePaths);
+});
+

--- a/src/main/scanImagesProcess.test.ts
+++ b/src/main/scanImagesProcess.test.ts
@@ -1,7 +1,5 @@
 import 'jest-extended';
-import child_process from 'child_process';
 import fs from 'fs-extra';
-import path from 'path';
 import { createMockServiceContainer } from '../test/mockCreators';
 import { createStore } from './createStore';
 import md5 from 'md5';
@@ -66,7 +64,6 @@ describe('scanImagesProcess', () => {
 	beforeAll( async () => {
 		const filePaths = await scanImages({webRoot: sitePath});
 		imageStats = await getImageStats({ filePaths: mockFilePaths, imageData: mockImageData });
-		console.log(filePaths, imageStats);
 	});
 
 	it('calls getImageFilePaths once with the correct args', () => {

--- a/src/main/scanImagesProcess.test.ts
+++ b/src/main/scanImagesProcess.test.ts
@@ -1,3 +1,16 @@
+import 'jest-extended';
+import child_process from 'child_process';
+import fs from 'fs-extra';
+import path from 'path';
+import { createMockServiceContainer } from '../test/mockCreators';
+import { createStore } from './createStore';
+import md5 from 'md5';
+import { scanImages, getImageStats } from './scanImagesProcess';
+
+const sitePath = '/Users/cool-man-joe/Local Sites/twice-baked-potato';
+const serviceContainer = createMockServiceContainer(sitePath);
+
+const imageDataStore = createStore();
 
 jest.mock('fs-extra');
 fs.statSync.mockImplementation((filePath: string) => ({
@@ -10,6 +23,27 @@ const mockFilePaths = [
 	'fake/path/file2.jpeg',
 ];
 
+const mockImageData = {
+	'40cf40c608bab653903bec92ab8bd26a': {
+		originalImageHash: '40cf40c608bab653903bec92ab8bd26a',
+		compressedImageHash: 'snthsnthsnthstnh',
+		filePath: 'fake/path/file1.jpeg',
+		originalSize: 10000000,
+		compressedSize: 5000000,
+		fileStatus: 'succeeded',
+		isChecked: true,
+	},
+	'b47c61eec6e37403c6be0cea67aa7a8e': {
+		originalImageHash: 'b47c61eec6e37403c6be0cea67aa7a8e',
+		compressedImageHash: 'hdhdhdhdhdhdhdhdhd',
+		filePath: 'fake/path/file2.jpeg',
+		originalSize: 7000000,
+		compressedSize: 3500000,
+		fileStatus: 'succeeded',
+		isChecked: true,
+	}
+}
+
 // mock out utils so that we don't accidentally make calls to fs, etc.
 // also this makes assertions much easier and utils should be tested independantly anyways
 jest.mock('./utils');
@@ -20,18 +54,46 @@ utils.getImageFilePaths.mockImplementation(() => {
 utils.getFileHash.mockImplementation((filePath) => {
 	return md5(filePath);
 });
-
-it('calls getImageFilePaths once with the correct args', () => {
-	expect(utils.getImageFilePaths.mock.calls).toBeArrayOfSize(1);
-
-	expect(utils.getImageFilePaths.mock.calls[0][0]).toEqual(
-		serviceContainer.siteData.getSite.mock.results[0].value.paths.webRoot
-	);
+utils.getImageIfCompressed.mockImplementation((fileHash, imageData) => {
+	if(fileHash === '40cf40c608bab653903bec92ab8bd26a') {
+		return mockImageData["40cf40c608bab653903bec92ab8bd26a"];
+	}
+	return undefined;
 });
 
-it('calls getFileHash once for each file ', () => {
-	const { mock } = utils.getFileHash;
-	expect(mock.calls).toBeArrayOfSize(mockFilePaths.length);
-	expect(mock.calls.map(call => call[0])).toIncludeSameMembers(mockFilePaths);
-});
+describe('scanImagesProcess', () => {
+	let imageStats;
+	beforeAll( async () => {
+		const filePaths = await scanImages({webRoot: sitePath});
+		imageStats = await getImageStats({ filePaths: mockFilePaths, imageData: mockImageData });
+		console.log(filePaths, imageStats);
+	});
 
+	it('calls getImageFilePaths once with the correct args', () => {
+		expect(utils.getImageFilePaths.mock.calls).toBeArrayOfSize(1);
+		expect(utils.getImageFilePaths.mock.calls[0][0]).toEqual(
+			serviceContainer.siteData.getSite('1234').longPath
+		);
+
+	});
+
+	it('calls getImageIfCompressed with the correct args', () => {
+		const { mock } = utils.getImageIfCompressed;
+		expect(mock.calls).toBeArrayOfSize(mockFilePaths.length);
+		expect(mock.calls[0][0]).toBe('40cf40c608bab653903bec92ab8bd26a');
+		expect(mock.calls[1][0]).toBe('b47c61eec6e37403c6be0cea67aa7a8e');
+	});
+
+	it('calls getFileHash once for each file ', () => {
+		const { mock } = utils.getFileHash;
+		expect(mock.calls).toBeArrayOfSize(mockFilePaths.length);
+		expect(mock.calls.map(call => call[0])).toIncludeSameMembers(mockFilePaths);
+	});
+
+	it('confirms getImageStats returns data in the correct format', () => {
+		expect(imageStats).toContainAllKeys(['40cf40c608bab653903bec92ab8bd26a', 'b47c61eec6e37403c6be0cea67aa7a8e']);
+		expect(imageStats['40cf40c608bab653903bec92ab8bd26a']).toContainKey('compressedImageHash');
+		expect(imageStats['b47c61eec6e37403c6be0cea67aa7a8e'].compressedImageHash).toBeUndefined;
+	});
+
+});

--- a/src/main/scanImagesProcess.test.ts
+++ b/src/main/scanImagesProcess.test.ts
@@ -15,6 +15,8 @@ fs.statSync.mockImplementation((filePath: string) => ({
 	size: Math.floor(Math.random() * 99999) + 700
 }));
 
+const mockFileHashOne = '40cf40c608bab653903bec92ab8bd26a';
+const mockFileHashTwo = 'b47c61eec6e37403c6be0cea67aa7a8e';
 
 const mockFilePaths = [
 	'fake/path/file1.jpeg',
@@ -22,8 +24,8 @@ const mockFilePaths = [
 ];
 
 const mockImageData = {
-	'40cf40c608bab653903bec92ab8bd26a': {
-		originalImageHash: '40cf40c608bab653903bec92ab8bd26a',
+	[mockFileHashOne]: {
+		originalImageHash: mockFileHashOne,
 		compressedImageHash: 'snthsnthsnthstnh',
 		filePath: 'fake/path/file1.jpeg',
 		originalSize: 10000000,
@@ -31,8 +33,8 @@ const mockImageData = {
 		fileStatus: 'succeeded',
 		isChecked: true,
 	},
-	'b47c61eec6e37403c6be0cea67aa7a8e': {
-		originalImageHash: 'b47c61eec6e37403c6be0cea67aa7a8e',
+	[mockFileHashTwo]: {
+		originalImageHash: mockFileHashTwo,
 		compressedImageHash: 'hdhdhdhdhdhdhdhdhd',
 		filePath: 'fake/path/file2.jpeg',
 		originalSize: 7000000,
@@ -53,8 +55,8 @@ utils.getFileHash.mockImplementation((filePath) => {
 	return md5(filePath);
 });
 utils.getImageIfCompressed.mockImplementation((fileHash, imageData) => {
-	if(fileHash === '40cf40c608bab653903bec92ab8bd26a') {
-		return mockImageData["40cf40c608bab653903bec92ab8bd26a"];
+	if(fileHash === mockFileHashOne) {
+		return mockImageData[mockFileHashOne];
 	}
 	return undefined;
 });
@@ -77,8 +79,8 @@ describe('scanImagesProcess', () => {
 	it('calls getImageIfCompressed with the correct args', () => {
 		const { mock } = utils.getImageIfCompressed;
 		expect(mock.calls).toBeArrayOfSize(mockFilePaths.length);
-		expect(mock.calls[0][0]).toBe('40cf40c608bab653903bec92ab8bd26a');
-		expect(mock.calls[1][0]).toBe('b47c61eec6e37403c6be0cea67aa7a8e');
+		expect(mock.calls[0][0]).toBe(mockFileHashOne);
+		expect(mock.calls[1][0]).toBe(mockFileHashTwo);
 	});
 
 	it('calls getFileHash once for each file ', () => {
@@ -88,9 +90,9 @@ describe('scanImagesProcess', () => {
 	});
 
 	it('confirms getImageStats returns data in the correct format', () => {
-		expect(imageStats).toContainAllKeys(['40cf40c608bab653903bec92ab8bd26a', 'b47c61eec6e37403c6be0cea67aa7a8e']);
-		expect(imageStats['40cf40c608bab653903bec92ab8bd26a']).toContainKey('compressedImageHash');
-		expect(imageStats['b47c61eec6e37403c6be0cea67aa7a8e'].compressedImageHash).toBeUndefined;
+		expect(imageStats).toContainAllKeys([mockFileHashOne, mockFileHashTwo]);
+		expect(imageStats[mockFileHashOne]).toContainKey('compressedImageHash');
+		expect(imageStats[mockFileHashTwo].compressedImageHash).toBeUndefined;
 	});
 
 });

--- a/src/main/scanImagesProcess.ts
+++ b/src/main/scanImagesProcess.ts
@@ -1,15 +1,15 @@
 import fs from 'fs-extra';
 import { getImageFilePaths, getImageIfCompressed, getFileHash } from './utils';
-import { SiteData, Store } from '../types';
+import { SiteImageData } from '../types';
 
-const scanImages = async (payload) => {
+export const scanImages = async (payload) => {
 	const { webRoot } = payload;
 	const filePaths = await getImageFilePaths(webRoot);
 
 	return filePaths;
 };
 
-const getImageStats = async (payload) => {
+export const getImageStats = async (payload) => {
 	const { filePaths, imageData } = payload;
 
 	return await filePaths.reduce(async (
@@ -21,6 +21,7 @@ const getImageStats = async (payload) => {
 		const fileHash = await getFileHash(filePath);
 
 		let compressedImage = getImageIfCompressed(fileHash, imageData)
+
 		if (compressedImage) {
 			return {
 				...(await imageDataAccumulator),

--- a/src/main/scanImagesProcess.ts
+++ b/src/main/scanImagesProcess.ts
@@ -1,6 +1,6 @@
 import fs from 'fs-extra';
 import { getImageFilePaths, getImageIfCompressed, getFileHash } from './utils';
-import { SiteImageData } from '../types';
+import { SiteData } from '../types';
 
 export const scanImages = async (payload) => {
 	const { webRoot } = payload;
@@ -21,7 +21,6 @@ export const getImageStats = async (payload) => {
 		const fileHash = await getFileHash(filePath);
 
 		let compressedImage = getImageIfCompressed(fileHash, imageData)
-
 		if (compressedImage) {
 			return {
 				...(await imageDataAccumulator),

--- a/src/test/mockLocalMain.ts
+++ b/src/test/mockLocalMain.ts
@@ -1,10 +1,8 @@
-import 'jest-extended';
-
 export const ServiceContainer = { cradle: { localLogger: {child: jest.fn()}}};
 
 export const getServiceContainer = () => ServiceContainer;
 
-export const workerFork = () => '';
+export const workerFork = jest.fn();
 
 export const childProcessMessagePromiseFactory = () => async (name: string, payload?: any) => {
 	if (name === 'get-file-paths') {

--- a/src/test/mockLocalMain.ts
+++ b/src/test/mockLocalMain.ts
@@ -1,0 +1,40 @@
+import 'jest-extended';
+
+export const ServiceContainer = { cradle: { localLogger: {child: jest.fn()}}};
+
+export const getServiceContainer = () => ServiceContainer;
+
+export const workerFork = () => '';
+
+export const childProcessMessagePromiseFactory = () => async (name: string, payload?: any) => {
+	if (name === 'get-file-paths') {
+		return [
+			'fake/path/file1.jpeg',
+			'fake/path/file2.jpeg',
+		]
+	}
+
+	if (name === 'get-image-stats') {
+		return {
+			'aoeuaoeuaoeuaou': {
+				originalImageHash: 'aoeuaoeuaoeuaou',
+				compressedImageHash: 'snthsnthsnthstnh',
+				filePath: 'fake/path/file1.jpeg',
+				originalSize: 10000000,
+				compressedSize: 5000000,
+				fileStatus: 'succeeded',
+				isChecked: true,
+			},
+			'yfyfyfyfyfyfyfyfy': {
+				originalImageHash: 'yfyfyfyfyfyfyfyfy',
+				compressedImageHash: 'hdhdhdhdhdhdhdhdhd',
+				filePath: 'fake/path/file2.jpeg',
+				originalSize: 7000000,
+				compressedSize: 3500000,
+				fileStatus: 'succeeded',
+				isChecked: true,
+			}
+		}
+	}
+	return []
+};


### PR DESCRIPTION
## Summary
- Fixes image optimizer tests that were broken due to changes in code
- Add new assertions to account for new code
- Adds one new test for `scanImagesProcess`