### PR TITLE
feat(LOC-2280): add "no images found" banner

### DIFF
--- a/src/renderer/overview.tsx
+++ b/src/renderer/overview.tsx
@@ -28,7 +28,7 @@ export const Overview = (props: IProps) => {
 
 	return <div className="overview_Container">
 		{remainingUncompressedImages > 0 &&
-			<Banner variant="warning" icon="warning" buttonText={'View Images'} buttonOnClick={() => onClickViewImages()}>
+			<Banner className="imageNotificationBanner" variant="success" icon="false" buttonText={'View Images'} buttonOnClick={() => onClickViewImages()}>
 				We've found{' '}<strong>{remainingUncompressedImages}</strong>images slowing down your site.
 			</Banner>
 		}

--- a/src/renderer/overview.tsx
+++ b/src/renderer/overview.tsx
@@ -15,6 +15,8 @@ export const Overview = (props: IProps) => {
 	const {
 		imageCount,
 		totalCompressedCount,
+		lastScan,
+		scanInProgress
 	} = scanImageState;
 
 	const onClickViewImages = () => {
@@ -28,6 +30,14 @@ export const Overview = (props: IProps) => {
 		{remainingUncompressedImages > 0 &&
 			<Banner variant="warning" icon="warning" buttonText={'View Images'} buttonOnClick={() => onClickViewImages()}>
 				We've found{' '}<strong>{remainingUncompressedImages}</strong>images slowing down your site.
+			</Banner>
+		}
+		{imageCount === 0
+		&& lastScan > 0
+		&& !scanInProgress
+		&&
+			<Banner variant="warning" icon="warning">
+				No images found on site.
 			</Banner>
 		}
 

--- a/style.css
+++ b/style.css
@@ -37,6 +37,10 @@
 	margin-left: auto;
 }
 
+.imageNotificationBanner {
+	padding-left: 20px;
+}
+
 /* File List Viewer Table */
 
 .fileListViewer_Column_Selected {


### PR DESCRIPTION
## Summary
- Adds a banner that displays on the overview page if no images are detected on the site
- Updates the styling for the "view images" banner to remove the warning icon and change color to green

## Technical
- Adds another Banner component to the overview component. Banner component displays only after a scan has been run; if no scan has been run on the site yet, the banner won't display. 
- Adds some styling changes to the original banner component.

## Screenshots

Brand new site, run scan for the first time: https://i.getf.ly/GGur76kj

Scan for images after adding images to a site that previously had none: https://i.getf.ly/rRuogGxj