### PR TITLE
feat(LOC-2281): IO Right-Click Context Menu

### DIFF
--- a/src/renderer/columnRenderers/colFileName.tsx
+++ b/src/renderer/columnRenderers/colFileName.tsx
@@ -29,6 +29,7 @@ export const ColFileName = ( props: IFileNameProps ) =>  {
 			<div
 				className='fileList_File_Name_Row'
 				title={formattedFilePath}
+				data-path={dataArgs.cellData}
 			>
 				{formattedFilePath}
 			</div>

--- a/src/renderer/contextMenu.ts
+++ b/src/renderer/contextMenu.ts
@@ -1,0 +1,55 @@
+import {
+	remote,
+	shell,
+} from 'electron';
+import { useEffect } from 'react';
+
+const { Menu, MenuItem } = remote;
+
+const isMac = process.platform === 'darwin'
+
+const revealPathMenuItem = (path: string) => {
+	return new MenuItem({
+		label: isMac ? 'Reveal in Finder' : 'Show folder',
+		click() {
+			shell.showItemInFolder(path)
+		}
+	})
+}
+
+const openPathMenuItem = (path: string) => {
+	return new MenuItem({
+		label: 'Open',
+		click() {
+			shell.openPath(path)
+		}
+	})
+}
+
+export default function useContextMenu() {
+	useEffect(() => {
+		const element = document.getElementById('no-context-menu');
+		if (element) {
+			element.addEventListener('contextmenu', (e) => {
+				e.preventDefault();
+			});
+		}
+
+		const IOFileListElement = document.getElementById('io-file-list');
+		if (IOFileListElement) {
+			IOFileListElement.addEventListener('contextmenu', (e) => {
+				e.preventDefault();
+				const path = e.target.dataset.path;
+				if (path) {
+					const menu = new Menu()
+					menu.append(revealPathMenuItem(path));
+					menu.append(openPathMenuItem(path));
+					menu.popup({ window: remote.getCurrentWindow() });
+					menu.once('menu-will-close', () => {
+						menu.closePopup();
+					});
+				}
+			});
+		}
+	}, []);
+}

--- a/src/renderer/contextMenu.ts
+++ b/src/renderer/contextMenu.ts
@@ -1,12 +1,13 @@
-import {
-	remote,
-	shell,
-} from 'electron';
+import { remote, shell } from 'electron';
 import { useEffect } from 'react';
 
 const { Menu, MenuItem } = remote;
 
-const isMac = process.platform === 'darwin'
+const isMac = process.platform === 'darwin';
+const contextEvent = 'contextmenu';
+const menuWillCloseEvent = 'menu-will-close';
+export const noContextMenuId = 'no-context-menu';
+export const ioFileListContextMenuId = 'io-file-list-context-menu';
 
 const revealPathMenuItem = (path: string) => {
 	return new MenuItem({
@@ -26,18 +27,18 @@ const openPathMenuItem = (path: string) => {
 	})
 }
 
-export default function useContextMenu() {
+export function useContextMenu() {
 	useEffect(() => {
-		const element = document.getElementById('no-context-menu');
+		const element = document.getElementById(noContextMenuId);
 		if (element) {
-			element.addEventListener('contextmenu', (e) => {
+			element.addEventListener(contextEvent, (e) => {
 				e.preventDefault();
 			});
 		}
 
-		const IOFileListElement = document.getElementById('io-file-list');
+		const IOFileListElement = document.getElementById(ioFileListContextMenuId);
 		if (IOFileListElement) {
-			IOFileListElement.addEventListener('contextmenu', (e) => {
+			IOFileListElement.addEventListener(contextEvent, (e) => {
 				e.preventDefault();
 				const path = e.target.dataset.path;
 				if (path) {
@@ -45,7 +46,7 @@ export default function useContextMenu() {
 					menu.append(revealPathMenuItem(path));
 					menu.append(openPathMenuItem(path));
 					menu.popup({ window: remote.getCurrentWindow() });
-					menu.once('menu-will-close', () => {
+					menu.once(menuWillCloseEvent, () => {
 						menu.closePopup();
 					});
 				}

--- a/src/renderer/fileListView/fileListView.tsx
+++ b/src/renderer/fileListView/fileListView.tsx
@@ -15,7 +15,7 @@ import { FileListHeader } from './fileListHeader';
 import { OptimizerStatus, SiteImageData, Preferences } from '../../types';
 import { IPC_EVENTS } from '../../constants';
 import { selectors, useStoreSelector } from '../store/store';
-import useContextMenu from '../contextMenu';
+import {useContextMenu, noContextMenuId, ioFileListContextMenuId } from '../contextMenu';
 
 interface IFileListViewProps {
 	siteImageData: SiteImageData;
@@ -140,9 +140,9 @@ export const FileListView = (props: IFileListViewProps) => {
 				siteID={siteID}
 			/>
 				<ProgressBar progress={siteImageData.compressionListCompletionPercentage} />
-			<div className='fileListViewer_File_List' id="no-context-menu">
+			<div className='fileListViewer_File_List' id={noContextMenuId}>
 				<VirtualTable
-					id="io-file-list"
+					id={ioFileListContextMenuId}
 					rowClassName='fileList_Virtual_Table_Row'
 					cellRenderer={cellRender}
 					data={siteImageData.optimizationStatus === OptimizerStatus.BEFORE ? uncompressedImages : selectedImages}

--- a/src/renderer/fileListView/fileListView.tsx
+++ b/src/renderer/fileListView/fileListView.tsx
@@ -15,6 +15,7 @@ import { FileListHeader } from './fileListHeader';
 import { OptimizerStatus, SiteImageData, Preferences } from '../../types';
 import { IPC_EVENTS } from '../../constants';
 import { selectors, useStoreSelector } from '../store/store';
+import useContextMenu from '../contextMenu';
 
 interface IFileListViewProps {
 	siteImageData: SiteImageData;
@@ -48,6 +49,7 @@ export const FileListView = (props: IFileListViewProps) => {
 		preferences,
 		siteID,
 	} = props;
+	useContextMenu();
 
 	const uncompressedImages = useStoreSelector(selectors.uncompressedSiteImages);
 	const selectedImages = useStoreSelector(selectors.selectedSiteImages);
@@ -138,8 +140,9 @@ export const FileListView = (props: IFileListViewProps) => {
 				siteID={siteID}
 			/>
 				<ProgressBar progress={siteImageData.compressionListCompletionPercentage} />
-			<div className='fileListViewer_File_List'>
+			<div className='fileListViewer_File_List' id="no-context-menu">
 				<VirtualTable
+					id="io-file-list"
 					rowClassName='fileList_Virtual_Table_Row'
 					cellRenderer={cellRender}
 					data={siteImageData.optimizationStatus === OptimizerStatus.BEFORE ? uncompressedImages : selectedImages}


### PR DESCRIPTION
**Summary:**

Add ability to right-click files within the Image Optimizer file list view and

- Reveal in Finder/Explorer
- Open image file

**Technical:**

It works, but honestly I'm not sure I liked how I went about two things in particular :

- How the new context-menu is attached using css `id="..."`
- Having to remove context menu if it already exists, so that we can attach a new context menu for its particular purposes. The drawback to this is we lose the context-menu from Local and replace it, which in particular means losing the "inspect element". Long story short, for couple days I tried to implement something where an add-on can relay to Local what context menu should show and where. I made some strides but for timeline purposes I had to scratch it and just get something working within Image Optimizer add-on itself.

![Screen Shot 2020-11-04 at 12 20 54 PM](https://user-images.githubusercontent.com/62450648/98153234-79aa5380-1e98-11eb-9dda-1a066005efbe.png)
![Screen Shot 2020-11-04 at 12 21 04 PM](https://user-images.githubusercontent.com/62450648/98153226-76af6300-1e98-11eb-9ab7-6df99bbccf52.png)
![Screen Shot 2020-11-04 at 12 22 14 PM](https://user-images.githubusercontent.com/62450648/98153233-7911bd00-1e98-11eb-8fbb-e9df5a13b759.png)
![Screen Shot 2020-11-04 at 12 21 23 PM](https://user-images.githubusercontent.com/62450648/98153231-78792680-1e98-11eb-95e4-31dc2ebcff7c.png)



