### PR TITLE
fix(LOC-232): fix styling and display Error text

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@getflywheel/local-addon-image-optimizer",
   "productName": "Image Optimizer",
-  "version": "1.0.3-beta",
+  "version": "1.0.4-beta",
   "author": "Local Team",
   "keywords": [
     "local-addon"

--- a/src/renderer/columnRenderers/colFileSize.tsx
+++ b/src/renderer/columnRenderers/colFileSize.tsx
@@ -1,28 +1,43 @@
 import React from 'react';
 import { IVirtualTableCellRendererDataArgs, Text } from '@getflywheel/local-components';
+import { FileStatus, OptimizerStatus } from '../../types';
 interface IFileSizeProps {
 	dataArgs: IVirtualTableCellRendererDataArgs
+	optimizerStatus: OptimizerStatus
 }
 
 export const ColFileSize = (props: IFileSizeProps) =>  {
-	const { dataArgs } = props;
+	const { dataArgs, optimizerStatus } = props;
 	const { colKey, rowData } = dataArgs;
 
 	let content = null;
 
-	if (typeof dataArgs.cellData === 'string') {
+	if (optimizerStatus === OptimizerStatus.BEFORE && colKey === 'compressedSize') {
 		content = dataArgs.cellData;
-	} else if (dataArgs.colKey === 'originalSize') {
+	}
+	else if (colKey === 'originalSize') {
 		content = dataArgs.isHeader
 			? dataArgs.cellData
-			: (dataArgs.rowData.originalSize / (1024*1024)).toFixed(2) + ' MB';
+			: (rowData.originalSize / (1024*1024)).toFixed(2) + ' MB';
 	} else if (colKey === 'compressedSize') {
+
 		content = dataArgs.isHeader
 			? dataArgs.cellData
-			: (dataArgs.rowData.compressedSize / (1024*1024)).toFixed(2) + ' MB';
+			: (rowData.compressedSize / (1024*1024)).toFixed(2) + ' MB';
 
-		if (rowData.errorMessage && !rowData.compressedSize) {
-			content = rowData.errorMessage;
+		if (rowData.errorMessage && !rowData.compressedSize && rowData.fileStatus === FileStatus.FAILED) {
+			content = (
+				<Text
+					privateOptions={{
+						fontWeight: 'bold',
+					}}
+					className={'colFileSize_Error_Text'}
+				>
+					Error
+				</Text>
+			);
+		} else if (!dataArgs.cellData) {
+			content = dataArgs.cellData;
 		}
 	}
 

--- a/src/renderer/fileListView/fileListView.tsx
+++ b/src/renderer/fileListView/fileListView.tsx
@@ -75,12 +75,14 @@ export const FileListView = (props: IFileListViewProps) => {
 				return (
 					<ColFileSize
 						dataArgs={dataArgs}
+						optimizerStatus={siteImageData.optimizationStatus}
 					/>
 				);
 			case 'compressedSize':
 				return (
 					<ColFileSize
 						dataArgs={dataArgs}
+						optimizerStatus={siteImageData.optimizationStatus}
 					/>
 				);
 			default: return null;

--- a/style.css
+++ b/style.css
@@ -70,6 +70,7 @@
 	margin-right: 31px;
 	margin-left: 20px;
 	align-self: center;
+	text-align: center;
 }
 
 .fileListViewer_Column_Compressed_Size, .fileListViewer_Column_Original_Size {
@@ -123,8 +124,9 @@
 }
 
 .spinner-svg {
-	margin: 0 !important;
+	margin: 0 auto !important;
 	width: 10px !important;
+	text-align: center;
 }
 
 .spinner-svg svg path {


### PR DESCRIPTION
## Summary
- Allow for `Error` text to display in UI if an image fails optimization
- Adjust styling of svg alignment to ensure they all match up

## Technical
I needed to add some additional logic to the ColFileSize cell renderer, in order to ensure the error message was displayed correctly.

I did quite a bit of smoke testing to double check this logic, but it could use another set of eyes on that logic specifically.

## Screenshot
<img width="1039" alt="screenshotIO" src="https://user-images.githubusercontent.com/7596682/98157341-d4df4480-1e9e-11eb-96ac-c9c217d12e7b.png">

