### PR TITLE
fix: add assertions to ensureBins test

### DIFF
--- a/src/main/ensureBins.test.ts
+++ b/src/main/ensureBins.test.ts
@@ -8,8 +8,8 @@ describe('Bundled binaries', () => {
 	it('includes jpeg-recompress for supported os\'s', () => {
 		const vendorDir = path.join(__dirname, '..', '..', 'vendor');
 
-		expect(fs.existsSync(path.join(vendorDir, 'darwin', 'jpeg-recompress')));
-		expect(fs.existsSync(path.join(vendorDir, 'linux', 'jpeg-recompress')));
-		expect(fs.existsSync(path.join(vendorDir, 'win32', 'jpeg-recompress.exe')));
+		expect(fs.existsSync(path.join(vendorDir, 'darwin', 'jpeg-recompress'))).toBeTrue();
+		expect(fs.existsSync(path.join(vendorDir, 'linux', 'jpeg-recompress'))).toBeTrue();
+		expect(fs.existsSync(path.join(vendorDir, 'win32', 'jpeg-recompress.exe'))).toBeTrue();
 	});
 });


### PR DESCRIPTION
I happened to notice that these three lines weren't actually making assertions after copying it into the backups addon where it also passed as well 😂

It seems weird to me that you can call `expect(...)` and never make any assertions and jest is totally cool with it. Seems like something it could at least warn about.