### PR TITLE
fix(LOC-2413): total compressed percentage getting passed non numbers

### DIFF
--- a/src/renderer/store/selectors.ts
+++ b/src/renderer/store/selectors.ts
@@ -65,7 +65,7 @@ const compressedSiteImages = createSelector(
 
 const totalImagesSizeBeforeCompression = createSelector(
 	selectActiveSite,
-	(imageData) => Object.values(imageData).reduce((totalSize, d) => {
+	({ imageData }) => Object.values(imageData).reduce((totalSize, d) => {
 		totalSize += d.originalSize;
 
 		return totalSize;
@@ -74,7 +74,7 @@ const totalImagesSizeBeforeCompression = createSelector(
 
 const originalSizeOfCompressedImages = createSelector(
 	selectActiveSite,
-	(imageData) => Object.values(imageData).reduce((size, d) => {
+	({ imageData }) => Object.values(imageData).reduce((size, d) => {
 		if (d.compressedImageHash) {
 			size += d.originalSize;
 		}
@@ -85,7 +85,7 @@ const originalSizeOfCompressedImages = createSelector(
 
 const sizeOfCompressedImages = createSelector(
 	selectActiveSite,
-	(imageData) => Object.values(imageData).reduce((size, d) => {
+	({ imageData }) => Object.values(imageData).reduce((size, d) => {
 		if (d.compressedImageHash) {
 			size += d.compressedSize;
 		}
@@ -119,7 +119,14 @@ const imageStats = createSelector(
 	sizeOfCompressedImages,
 	compressedSiteImages,
 	erroredTotalCount,
-	(imageCount, originalTotalSize, compressedImagesOriginalSize, compressedTotalSize, compressedSiteImages, erroredTotalCount) => ({
+	(
+		imageCount,
+		originalTotalSize,
+		compressedImagesOriginalSize,
+		compressedTotalSize,
+		compressedSiteImages,
+		erroredTotalCount,
+	) => ({
 		imageCount,
 		originalTotalSize,
 		compressedImagesOriginalSize,


### PR DESCRIPTION
### Summary

The "total reductions" line in the overview view was displaying `NaN`

<img width="748" alt="Screen Shot 2020-11-24 at 9 59 28 AM" src="https://user-images.githubusercontent.com/21110659/100132615-46c9fe80-2e4b-11eb-9f4f-f37ee3b6bd7c.png">

Additionally, the other "stats" lines were incorrect although this was harder see as they were still rendering numbers.

### Technical

The fix was to ensure that selectors were using the `imageData` object on `SiteData` rather than using `SiteData`.

<img width="734" alt="Screen Shot 2020-11-24 at 11 52 38 AM" src="https://user-images.githubusercontent.com/21110659/100132789-8db7f400-2e4b-11eb-96ef-b6c3cb458424.png">

### Reference
[LOC-2413](https://getflywheel.atlassian.net/browse/LOC-2413)
