### PR TITLE
refactor: update the Image Optimizer content hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,6 @@
     "redux"
   ],
   "engines": {
-    "local-by-flywheel": "^5.9.3"
+    "local-by-flywheel": "^5.9.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@getflywheel/local-addon-image-optimizer",
   "productName": "Image Optimizer",
-  "version": "1.1.1",
+  "version": "1.1.0",
   "author": "Local Team",
   "keywords": [
     "local-addon"
@@ -90,6 +90,6 @@
     "redux"
   ],
   "engines": {
-    "local-by-flywheel": "^5.9.4"
+    "local-by-flywheel": "^5.9.3"
   }
 }

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -56,7 +56,7 @@ export default async function (context) {
 
 	const ImageOptimizerHOC = withStoreProvider(ImageOptimizer);
 
-	hooks.addContent('local-addon-image-optimizer:site-info-content', ({ match }) => {
+	hooks.addContent('siteToolsImageOptimizer', ({ match }) => {
 		return (
 			<ImageOptimizerHOC match={match} />
 		)


### PR DESCRIPTION
## Summary

Local is going to use the old Image Optimizer content hook, so this migrates back.

Also downgrades the version and minimum Local versions so that we can immediately cut a build and release it once this is merged.

