### PR TITLE
fix(LOC-2456): Reduce times image optimize is submitted to analytics

### DIFF
--- a/src/renderer/store/sites.ts
+++ b/src/renderer/store/sites.ts
@@ -148,7 +148,6 @@ export const sitesSlice = createSlice({
 			return state;
 		},
 		optimizationRequested: (state, action: PayloadAction<{ siteID: string, selectedImageIDs: string[] }>) => {
-			reportAnalytics(ANALYTIC_EVENT_TYPES.OPTIMIZE_START);
 
 			return mergeSiteState(
 				state,

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,6 +28,7 @@ export interface SiteData {
 	imageData: { [imageID: string]: ImageData };
 	lastScan?: number;
 	scanInProgress?: boolean;
+	// eslint-disable-next-line no-undef
 	scanError?: GenericObject;
 	areAllFilesSelected?: boolean;
 	optimizationStatus?: OptimizerStatus;


### PR DESCRIPTION
**Summary:**

We were duplicating some analytic data for when an image optimization was started. Removing one instance to stop bad data being submitted.