### PR TITLE
fix(LOC-2564): show red Error text on optimization fail

### DIFF
--- a/src/renderer/columnRenderers/colFileSize.tsx
+++ b/src/renderer/columnRenderers/colFileSize.tsx
@@ -19,13 +19,9 @@ export const ColFileSize = (props: IFileSizeProps) => {
 
 	let content = null;
 
-	const shouldDisplayErrorMessage = () => {
-		return;
-	};
-
 	const errorCompressingImage = (
 		colKey === 'compressedSize'
-		&& rowData.errorOverrideMessage
+		&& rowData.errorMessage
 		&& !rowData.compressedSize
 	);
 


### PR DESCRIPTION
## Summary

When running image optimization, if the image failed to optimize successfully, it would NOT show a red Error notice in the UI. This fixes that so the Error notice displays as expected!

## Technical

This ended up being a super simple fix - one of the conditionals for displaying the error had an incorrect reference. After changing that to the correct reference, everything displays correctly now!

## Screenshots

Overview tab and File List View:

https://i.getf.ly/04uNjLpj

https://i.getf.ly/6quxlE6e

## Ticket

- https://getflywheel.atlassian.net/browse/LOC-2564