### PR TITLE
fix(LOC-2516): select only non-compressed, non-errored images

### DIFF
--- a/src/renderer/store/sites.ts
+++ b/src/renderer/store/sites.ts
@@ -57,7 +57,11 @@ export const sitesSlice = createSlice({
 					...generateInitialSiteState(),
 				};
 
-				Object.values(acc[id].imageData).forEach((d) => d.isChecked = true);
+				Object.values(acc[id].imageData).forEach((d) => {
+					if (!d.compressedImageHash && !d.errorMessage) {
+						d.isChecked = true;
+					}
+				});
 
 				return acc;
 			}, {} as SiteDataBySiteID);
@@ -142,7 +146,12 @@ export const sitesSlice = createSlice({
 			isChecked ? reportAnalytics(ANALYTIC_EVENT_TYPES.OPTIMIZE_INCLUDE_ALL_FILES) :
 				reportAnalytics(ANALYTIC_EVENT_TYPES.OPTIMIZE_EXCLUDE_ALL_FILES);
 
-			Object.values(siteState.imageData).forEach((d) => d.isChecked = isChecked);
+			Object.values(siteState.imageData).forEach((d) => {
+				if (!d.compressedImageHash && !d.errorMessage) {
+					d.isChecked = isChecked;
+				}
+			});
+
 			siteState.areAllFilesSelected = isChecked;
 
 			return state;


### PR DESCRIPTION
## Summary

When using the "toggle all" checkbox on the File List View page for Image Optimizer, the "select all" box would select the entire list of images, both compressed and uncompressed. This led to a visual bug where ALL images for the site would appear during the optimization process, instead of just the images that were uncompressed. 

This fixes that, so only uncompressed images are selected and displayed by the "toggle all" checkbox.

## Technical

This ended up being a relatively simple fix. I updated the conditionals in the "hydrateSites" reducer, so that the initial state for a site is set up with only uncompressed images being checked.

Then I updated the "setAllImagesSelected" reducer so that it only toggles "isChecked" for images that have not errored previously and have not previously been compressed. V

## Screenshots

Recording of running two optimization settings in a row to confirm only selected files are displayed.

https://i.getf.ly/WnulgAyp

## Ticket

https://getflywheel.atlassian.net/browse/LOC-2516