### PR TITLE
test: Hide last scan date on Spectron tests.

### DIFF
--- a/src/renderer/lastOptimizeStatus.tsx
+++ b/src/renderer/lastOptimizeStatus.tsx
@@ -45,7 +45,7 @@ const LastOptimizeStatus: React.FC<IProps> = (props: IProps) => {
 				>
 					{lastScan
 						? <Text
-							className="lastOptimizeStatus_Text"
+							className={classnames('lastOptimizeStatus_Text', 'hideOnSpectron')}
 							privateOptions={{
 								fontWeight: 'bold',
 							}}


### PR DESCRIPTION
This text often causes our Percy snapshot tests to fail due to it's dynamic nature. We've got a new class in Local that will block out this text when running in Spectron, so we should use it here!