### PR TITLE
refactor: standardize how addon hooks into Tools page in Local

### DIFF
--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import fs from 'fs-extra';
 import path from 'path';
 import { Provider } from 'react-redux';
 import * as LocalRenderer from '@getflywheel/local/renderer';
@@ -14,6 +15,8 @@ const stylesheetPath = path.resolve(__dirname, '../style.css');
 
 export default async function (context) {
 	const { React, hooks } = context;
+	const packageJSON = fs.readJsonSync(path.join(__dirname, '../package.json'));
+	const addonID = packageJSON.slug;
 
 	setupListeners();
 
@@ -48,15 +51,22 @@ export default async function (context) {
 
 	const SiteInfoMenuItemHOC = withStoreProvider(SiteInfoMenuItem);
 
-	hooks.addContent('local-addon-image-optimizer:site-info-menu-item', () => (
-		<SiteInfoMenuItemHOC />
-	));
-
 	const ImageOptimizerHOC = withStoreProvider(ImageOptimizer);
 
-	hooks.addContent('siteToolsImageOptimizer', ({ match }) => (
-		<ImageOptimizerHOC match={match} />
-	));
+	hooks.addFilter(
+		'siteInfoToolsItem',
+		(menu) => {
+			menu.push({
+				path: `/${addonID}`,
+				menuItem: <SiteInfoMenuItemHOC />,
+				render: ({ site }) => (
+					<ImageOptimizerHOC siteID={site.id} />
+				),
+			});
+			return menu;
+		},
+	);
+
 
 	hooks.addFilter(
 		'preferencesMenuItems',

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -7,13 +7,12 @@ import { store, actions, selectors, useStoreSelector } from './store/store';
 import { reportAnalytics, ANALYTIC_EVENT_TYPES } from './analytics';
 
 interface IProps {
-	match: { params: { siteID: string; } };
+	siteID: string;
 }
 
 
 const ImageOptimizer = (props: IProps) => {
-	const { match } = props;
-	const { siteID } = match.params;
+	const { siteID } = props;
 
 	const [activeSiteID, preferences, siteData] = useStoreSelector((state) => ([
 		state.activeSiteID,


### PR DESCRIPTION
## Summary

This is a small PR that standardizes the addon to hook into the Local Tools tab in the same way as every other addon.

This removes the need for Local to continue carrying a special hook just for Image Optimizer.

## Technical

- changes the addon from using two Hooks.addContent hooks, to a single Hooks.addFilter hook, using the same hook as all other addons.