### PR TITLE
[LOC-5969] Ensure compatibility with Local 9

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "test:watch": "yarn test --watch"
   },
   "devDependencies": {
-    "@electron/remote": "^2.0.8",
     "@getflywheel/eslint-config-local": "1.0.4",
     "@getflywheel/local": "^9.0.0",
     "@types/classnames": "^2.2.9",
@@ -69,6 +68,7 @@
     "react-router-dom": "^4.3.1"
   },
   "dependencies": {
+    "@electron/remote": "^2.1.2",
     "@getflywheel/local-components": "^17.8.0",
     "@reduxjs/toolkit": "^1.4.0",
     "classnames": "^2.2.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@getflywheel/local-addon-image-optimizer",
   "productName": "Image Optimizer",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "author": "Local Team",
   "keywords": [
     "local-addon"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@electron/remote": "^2.0.8",
     "@getflywheel/eslint-config-local": "1.0.4",
-    "@getflywheel/local": "^8.0.0",
+    "@getflywheel/local": "^9.0.0",
     "@types/classnames": "^2.2.9",
     "@types/dateformat": "^3.0.1",
     "@types/jest": "^26.0.13",
@@ -69,7 +69,7 @@
     "react-router-dom": "^4.3.1"
   },
   "dependencies": {
-    "@getflywheel/local-components": "^17.7.1",
+    "@getflywheel/local-components": "^17.8.0",
     "@reduxjs/toolkit": "^1.4.0",
     "classnames": "^2.2.6",
     "dateformat": "^5.0.3",

--- a/src/renderer/contextMenu.ts
+++ b/src/renderer/contextMenu.ts
@@ -6,6 +6,7 @@ import { selectors, actions, store } from './store/store';
 import invokeModal from './invokeModal';
 import ConfirmRestoreBackupModalContents from './confirmRestoreBackupModalContents';
 import { reportAnalytics, ANALYTIC_EVENT_TYPES } from './analytics';
+import path from 'path';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const remote = require(`@electron/remote`);
@@ -21,15 +22,15 @@ export const uncompressedImageListContextMenu = 'uncompressed-image-list-context
 export const comprepssedImageListNoContextMenu = 'compressed-image-list-no-context-menu';
 export const compressedImageListContextMenu = 'compressed-image-list-context-menu';
 
-const revealPathMenuItem = (path: string) => new MenuItem({
+const revealPathMenuItem = (imagePath: string) => new MenuItem({
 	label: isMac ? 'Reveal in Finder' : 'Show folder',
 	click () {
-		shell.showItemInFolder(path);
+		shell.openPath(path.dirname(imagePath));
 
 		/**
-			 * Generally, these calls should live in redux reducers, but given that we do not have
-			 * reducers for these, this location makes the most sense
-			 */
+		 * Generally, these calls should live in redux reducers, but given that we do not have
+		 * reducers for these, this location makes the most sense
+		 */
 		reportAnalytics(ANALYTIC_EVENT_TYPES.CONTEXTMENU_REVEAL_IN_FINDER);
 	},
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -405,10 +405,10 @@
   optionalDependencies:
     global-agent "^3.0.0"
 
-"@electron/remote@^2.0.8":
-  version "2.0.8"
-  resolved "https://registry.yarnpkg.com/@electron/remote/-/remote-2.0.8.tgz#85ff321f0490222993207106e2f720273bb1a5c3"
-  integrity sha512-P10v3+iFCIvEPeYzTWWGwwHmqWnjoh8RYnbtZAb3RlQefy4guagzIwcWtfftABIfm6JJTNQf4WPSKWZOpLmHXw==
+"@electron/remote@^2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@electron/remote/-/remote-2.1.2.tgz#52a97c8faa5b769155b649ef262f2f8c851776e6"
+  integrity sha512-EPwNx+nhdrTBxyCqXt/pftoQg/ybtWDW3DUWHafejvnB1ZGGfMpv6e15D8KeempocjXe78T7WreyGGb3mlZxdA==
 
 "@eslint/eslintrc@^0.4.3":
   version "0.4.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -430,16 +430,12 @@
   resolved "https://registry.yarnpkg.com/@getflywheel/eslint-config-local/-/eslint-config-local-1.0.4.tgz#2fab6bb77b63ec123e831534f50e1d3c7c135571"
   integrity sha512-GvnhhT3XaNipDdVvHifWbKjoFpLAbezkKsYBGfDF4uG/9gWo5UX9YLANPlzSLRyvgBrX0+27S5Cu8YE/yM7kPg==
 
-"@getflywheel/local-components@^17.7.1":
-  version "17.7.1"
-  resolved "https://registry.yarnpkg.com/@getflywheel/local-components/-/local-components-17.7.1.tgz#a6f14efb33bd62b801383ad2a554e2425013e87d"
-  integrity sha512-wgVZqh0CKzJzjZfQRPR5KXVth/bIBMHWeFLuIsJGtDQTBr5Yz7lS9u2Pb72Bo3KA9nBX4bJTmLnxsc92ofLv8A==
+"@getflywheel/local-components@^17.8.0":
+  version "17.8.0"
+  resolved "https://registry.yarnpkg.com/@getflywheel/local-components/-/local-components-17.8.0.tgz#ceb0219aedf183f14f5f84825111e3c3af044a7f"
+  integrity sha512-8BJvS3hNm3TSoF08KCqCvsBvy/5iORGOeM5kV25eAHcPlx1tc++KmtE+HuBvJ1iYVM3mdl3scCb37bEhCKpA1g==
   dependencies:
-    "@electron/remote" "^2.0.8"
     "@popperjs/core" "^2.9.2"
-    "@types/lz-string" "^1.3.34"
-    "@types/shortid" "^0.0.29"
-    "@types/untildify" "^3.0.0"
     classnames "^2.2.6"
     clipboard-copy "^3.1.0"
     fuse.js "^6.6.2"
@@ -455,21 +451,21 @@
     react-popper "^2.2.5"
     react-resize-observer "^1.1.1"
     react-router-dom "^5.0.1"
+    react-timeago "^4.1.9"
     react-toastify "^9.1.1"
     react-truncate-markup "^3.0.0"
-    shortid "^2.2.16"
     untildify "^4.0.0"
 
-"@getflywheel/local@^8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@getflywheel/local/-/local-8.0.0.tgz#96a3f840d3420f757c873a5887ee015022fcb417"
-  integrity sha512-+oE98PGSd/MRFgKpYhVyMeN5pPdhgcDdAqacyKfwWu3q1J8m4zbB6Uh6Nudr3zIFAt7eyDmrhrQDmXUvdjy4Jg==
+"@getflywheel/local@^9.0.0":
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/@getflywheel/local/-/local-9.0.0.tgz#ef4f08931e2da4e5c7ba40c257a1d98cf0451ddb"
+  integrity sha512-ALWG2Ft6/N9ggZzqJkmixDqOHu6VbWDFkmd67LZlg/ok4Ss2k/1jV8ZARxU+4FZaJ8hgpfz5MbtwAO6vIutYbg==
   dependencies:
-    "@types/node" "^18.15.0"
+    "@types/node" "^18.18.0"
     apollo-boost "^0.1.21"
     awilix "^4.2.5"
     cross-fetch "^3.1.5"
-    electron "25.8.1"
+    electron "25.8.4"
     graphql "^15.4.0"
     graphql-subscriptions "^1.1.0"
     graphql-tag "^2.11.0"
@@ -974,11 +970,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/lz-string@^1.3.34":
-  version "1.3.34"
-  resolved "https://registry.yarnpkg.com/@types/lz-string/-/lz-string-1.3.34.tgz#69bfadde419314b4a374bf2c8e58659c035ed0a5"
-  integrity sha512-j6G1e8DULJx3ONf6NdR5JiR2ZY3K3PaaqiEuKYkLQO0Czfi1AzrtjfnfCROyWGeDd5IVMKCwsgSmMip9OWijow==
-
 "@types/node@*":
   version "16.11.5"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.5.tgz#e91be5ba4ab88c06095e7b61f9ad1767a1093faf"
@@ -994,10 +985,17 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.16.tgz#e3733f46797b9df9e853ca9f719c8a6f7b84cd26"
   integrity sha512-ydLaGVfQOQ6hI1xK2A5nVh8bl0OGoIfYMxPWHqqYe9bTkWCfqiVvZoh2I/QF2sNSkZzZyROBoTefIEI+PB6iIA==
 
-"@types/node@^18.11.18", "@types/node@^18.15.0":
+"@types/node@^18.11.18":
   version "18.17.18"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.17.18.tgz#acae19ad9011a2ab3d792232501c95085ba1838f"
   integrity sha512-/4QOuy3ZpV7Ya1GTRz5CYSz3DgkKpyUptXuQ5PPce7uuyJAOR7r9FhkmxJfvcNUXyklbC63a+YvB3jxy7s9ngw==
+
+"@types/node@^18.18.0":
+  version "18.19.29"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.29.tgz#e7e9d796c1e195be7e7daf82b4abc50d017fb9db"
+  integrity sha512-5pAX7ggTmWZdhUrhRWLPf+5oM7F80bcKVCBbr0zwEkTNzTJL2CWQjznpFgHYy6GrzkYi2Yjy7DHKoynFxqPV8g==
+  dependencies:
+    undici-types "~5.26.4"
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
@@ -1057,11 +1055,6 @@
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
   integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
 
-"@types/shortid@^0.0.29":
-  version "0.0.29"
-  resolved "https://registry.yarnpkg.com/@types/shortid/-/shortid-0.0.29.tgz#8093ee0416a6e2bf2aa6338109114b3fbffa0e9b"
-  integrity sha512-9BCYD9btg2CY4kPcpMQ+vCR8U6V8f/KvixYD5ZbxoWlkhddNF5IeZMVL3p+QFUkg+Hb+kPAG9Jgk4bnnF1v/Fw==
-
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
@@ -1071,11 +1064,6 @@
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
-
-"@types/untildify@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@types/untildify/-/untildify-3.0.0.tgz#cd3e6624e46ccf292d3823fb48fa90dda0deaec0"
-  integrity sha512-FTktI3Y1h+gP9GTjTvXBP5v8xpH4RU6uS9POoBcGy4XkS2Np6LNtnP1eiNNth4S7P+qw2c/rugkwBasSHFzJEg==
 
 "@types/yargs-parser@*":
   version "20.2.1"
@@ -2539,10 +2527,10 @@ electron-to-chromium@^1.4.526:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.530.tgz#c31a44346739bb34acb1a4026a07c3b9eeeb326c"
   integrity sha512-rsJ9O8SCI4etS8TBsXuRfHa2eZReJhnGf5MHZd3Vo05PukWHKXhk3VQGbHHnDLa8nZz9woPCpLCMQpLGgkGNRA==
 
-electron@25.8.1:
-  version "25.8.1"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-25.8.1.tgz#092fab5a833db4d9240d4d6f36218cf7ca954f86"
-  integrity sha512-GtcP1nMrROZfFg0+mhyj1hamrHvukfF6of2B/pcWxmWkd5FVY1NJib0tlhiorFZRzQN5Z+APLPr7aMolt7i2AQ==
+electron@25.8.4:
+  version "25.8.4"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-25.8.4.tgz#b50877aac7d96323920437baf309ad86382cb455"
+  integrity sha512-hUYS3RGdaa6E1UWnzeGnsdsBYOggwMMg4WGxNGvAoWtmRrr6J1BsjFW/yRq4WsJHJce2HdzQXtz4OGXV6yUCLg==
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^18.11.18"
@@ -5019,11 +5007,6 @@ ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-nanoid@^2.1.0:
-  version "2.1.11"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-2.1.11.tgz#ec24b8a758d591561531b4176a01e3ab4f0f0280"
-  integrity sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA==
-
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -5778,6 +5761,11 @@ react-svg-loader@^3.0.3:
     loader-utils "^1.2.3"
     react-svg-core "^3.0.3"
 
+react-timeago@^4.1.9:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/react-timeago/-/react-timeago-4.4.0.tgz#4520dd9ba63551afc4d709819f52b14b9343ba2b"
+  integrity sha512-Zj8RchTqZEH27LAANemzMR2RpotbP2aMd+UIajfYMZ9KW4dMcViUVKzC7YmqfiqlFfz8B0bjDw2xUBjmcxDngA==
+
 react-toastify@^9.1.1:
   version "9.1.3"
   resolved "https://registry.yarnpkg.com/react-toastify/-/react-toastify-9.1.3.tgz#1e798d260d606f50e0fab5ee31daaae1d628c5ff"
@@ -6224,13 +6212,6 @@ shellwords@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
-
-shortid@^2.2.16:
-  version "2.2.16"
-  resolved "https://registry.yarnpkg.com/shortid/-/shortid-2.2.16.tgz#b742b8f0cb96406fd391c76bfc18a67a57fe5608"
-  integrity sha512-Ugt+GIZqvGXCIItnsL+lvFJOiN7RYqlGy7QE41O3YC1xbNSeDGIRO7xg2JJXIAj1cAGnOeC1r7/T9pgrtQbv4g==
-  dependencies:
-    nanoid "^2.1.0"
 
 side-channel@^1.0.4:
   version "1.0.4"
@@ -6893,6 +6874,11 @@ unbox-primitive@^1.0.1:
     has-bigints "^1.0.1"
     has-symbols "^1.0.2"
     which-boxed-primitive "^1.0.2"
+
+undici-types@~5.26.4:
+  version "5.26.5"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
+  integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
 unherit@^1.0.4:
   version "1.1.3"


### PR DESCRIPTION
- Bumps add-on version.
- Bumps local and local-components versions.
- Moves `@electron/remote` from devDependencies to dependencies to ensure the add-on loads in Local 9. (An alternative to a larger refactoring to replace electron/remote with IPC calls, which I think is fair given the timeline and desired goal of making this work with Local 9.)
- Noticed "Show in Finder" in the context menu doesn't work on macOS, so smuggled in a quick fix for that here.

For https://wpengine.atlassian.net/browse/LOC-5969.

## Testing
- [x] Add-on loads in Local 9.0. 
- [x] Tools → Image Optimizer pane loads.
- [x] Images can be optimized.
- [x] Context menu still loads and menu items function in image list after optimization.
- [x] Optimus Prime is still able to summon all Autobots.

<img width="1448" alt="Screenshot 2024-04-04 at 08 53 14" src="https://github.com/getflywheel/local-addon-image-optimizer/assets/647669/8224ac8a-e1df-4d2b-bf46-858ff98d634b">
<img width="736" alt="Screenshot 2024-04-04 at 08 53 43" src="https://github.com/getflywheel/local-addon-image-optimizer/assets/647669/40bafdf6-5750-40fc-9c35-8c40bbbad29b">
<img width="725" alt="Screenshot 2024-04-04 at 08 54 43" src="https://github.com/getflywheel/local-addon-image-optimizer/assets/647669/c50d99fb-efbd-491e-ba27-417f75b79601">
<img width="1448" alt="Screenshot 2024-04-04 at 08 51 21" src="https://github.com/getflywheel/local-addon-image-optimizer/assets/647669/aeae45d5-3eba-4012-a6cb-76d815fb2c41">
<img width="1448" alt="Screenshot 2024-04-04 at 08 52 50" src="https://github.com/getflywheel/local-addon-image-optimizer/assets/647669/8c1229a2-8f03-4bb0-8c8c-8c40239651fe">
<img src="https://github.com/getflywheel/local-addon-image-optimizer/assets/647669/05f83dad-f3ca-44c9-af80-e9113aac78e8">
